### PR TITLE
fix: use proper temp directory

### DIFF
--- a/config/default/deployment.yaml
+++ b/config/default/deployment.yaml
@@ -20,8 +20,10 @@ spec:
             quay.io/konflux-ci/release-service-monitor:dbb20f80954f2657c455779b0033ee0cd1494d79
           command: ["/bin/metrics-server", "/config/server-config.yaml"]
           env:
-            # the HOME is mandatory to not break the quay check
+            # required as the temporary directories are read-only
             - name: HOME
+              value: /var/tmp
+            - name: TMPDIR
               value: /var/tmp
           envFrom:
             - secretRef:

--- a/pkg/checks/quay.go
+++ b/pkg/checks/quay.go
@@ -81,7 +81,8 @@ func (c *QuayCheck) pullImage() (CheckResult, error) {
 		return CheckResult{1, "Failed", err.Error()}, err
 	}
 
-	tmpdir, err = os.MkdirTemp("/var/tmp", "quaycheck-")
+	// the os.TempDir() value can be overwritten with the TMPDIR var
+	tmpdir, err = os.MkdirTemp(os.TempDir(), "quaycheck-")
 	c.log.Println(fmt.Sprintf("temporary directory is %s", tmpdir))
 	if err != nil {
 		c.log.Println(fmt.Sprintf("check failed: %s", err.Error()))


### PR DESCRIPTION
This commit changes the quay check to use os.TempDir instead of /var/tmp. The advantage is that this can be overwritten by TMPDIR variable.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>