### PR TITLE
chore(RELEASE-2405): add shared renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>konflux-ci/release-service-automations//mintMaker/default"]
+}

--- a/.github/workflows/check-renovate-config.yaml
+++ b/.github/workflows/check-renovate-config.yaml
@@ -1,0 +1,16 @@
+---
+name: Check Renovate Config
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: konflux-ci/renovate-config-validator-action@adca50c2ce7ba1f3fab4d15f8783ad239f8090ae # main
+        with:
+          config_file: .github/renovate.json


### PR DESCRIPTION
Move renovate.json to .github/ and extend the base preset from release-service-automations. Add check-renovate-config CI.
Jira: RELEASE-2405

depends on https://github.com/konflux-ci/release-service-automations/pull/18